### PR TITLE
fix: handle octal interpretation in starttask auto-numbering

### DIFF
--- a/bin/starttask
+++ b/bin/starttask
@@ -70,7 +70,7 @@ mkdir -p "$wt_root" "$tmuxp_priv"
 if [[ -z $slug ]]; then
   last=$(find "$wt_root" -maxdepth 1 -type d \
            -regex ".*/[0-9][0-9][0-9]" | xargs -I {} basename {} | sort -n | tail -1 || true)
-  next=$(( ${last:-0} + 1 ))
+  next=$(( 10#${last:-0} + 1 ))
   slug=$(printf "%03d" "$next")
 fi
 


### PR DESCRIPTION
## Summary
- Fixed error when worktree numbers contain digits 8 or 9 (e.g., 008, 009)
- Bash was interpreting these as invalid octal numbers
- Added `10#` prefix to force base-10 interpretation

## Test plan
- [x] Tested with existing worktree 008 - no longer throws "value too great for base" error
- [x] Successfully created worktree 009
- [x] Auto-numbering continues to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)