### PR TITLE
fix: prevent tmux auto-switching after finishtask

### DIFF
--- a/bin/finishtask
+++ b/bin/finishtask
@@ -94,19 +94,8 @@ if [[ -f "$tmuxp_config" ]]; then
   rm -f "$tmuxp_config"
 fi
 
-# ---- Kill tmux session ------------------------------------------------------
-echo "Cleaning up tmux session..."
-# We need to detach first if we're inside the session we're killing
-if [[ "$(tmux display-message -p '#S')" == "$session_name" ]]; then
-  # Kill the session and detach in one go
-  tmux kill-session -t "$session_name"
-else
-  # We're in a different session, just kill it
-  tmux kill-session -t "$session_name"
-fi
-
 # ---- Success message --------------------------------------------------------
-# This will only show if we were attached to a different session
+# Show success message before killing the session
 cat <<EOF
 ✔ Task cleanup complete!
   - Branch: $current_branch ($commit_count commits)
@@ -118,3 +107,20 @@ Remember to:
   - Create a PR if ready for review
   - Delete the remote branch after merge
 EOF
+
+# ---- Kill tmux session ------------------------------------------------------
+echo ""
+echo "Detaching from tmux session..."
+# We need to detach first if we're inside the session we're killing
+if [[ "$(tmux display-message -p '#S')" == "$session_name" ]]; then
+  # Small delay to ensure message is visible
+  sleep 1
+  # Detach from tmux first, then kill the session
+  # This prevents tmux from auto-switching to another session
+  tmux detach-client
+  # Kill the session after detaching (this runs in the parent shell)
+  tmux kill-session -t "$session_name" 2>/dev/null || true
+else
+  # We're in a different session, just kill it
+  tmux kill-session -t "$session_name"
+fi


### PR DESCRIPTION
## Summary
- Fixes issue where `finishtask` would switch to another random tmux session instead of dropping to shell
- Ensures success message is always visible before session termination
- Adds proper detach before kill-session to prevent auto-switching behavior

## Changes
- Moved success message display before session termination
- Added `tmux detach-client` before `kill-session` when running inside the target session
- Added 1-second delay to ensure message visibility
- This ensures users drop back to their shell instead of another tmux session

## Test plan
- [x] Run `starttask` to create a new worktree/session
- [x] Make some commits in the session
- [x] Run `finishtask` from inside the session
- [x] Verify success message is displayed
- [x] Verify you're dropped to shell, not another tmux session
- [x] Verify worktree and session are properly cleaned up

🤖 Generated with [Claude Code](https://claude.ai/code)