### PR TITLE
Fix agentsmd Claude prompt inclusion and add line wrapping

### DIFF
--- a/bin/agentsmd
+++ b/bin/agentsmd
@@ -356,14 +356,32 @@ process_migration() {
   local processed_content=""
   local remaining_content="$content"
   
-  # Process all Claude prompts in the migration
-  while [[ "$remaining_content" =~ \{\{CLAUDE_PROMPT\}\}([^\{]*)\{\{/CLAUDE_PROMPT\}\} ]]; do
-    local before_match="${remaining_content%%{{CLAUDE_PROMPT}}*}"
-    local full_match="${BASH_REMATCH[0]}"
-    local prompt="${BASH_REMATCH[1]}"
+  # Process all Claude prompts in the migration using a more robust approach
+  while true; do
+    # Find the start of the next Claude prompt
+    local start_marker="{{CLAUDE_PROMPT}}"
+    local end_marker="{{/CLAUDE_PROMPT}}"
     
-    # Add content before the match (which doesn't include the {{CLAUDE_PROMPT}} marker)
+    # Check if there's a Claude prompt in the remaining content
+    if [[ "$remaining_content" != *"$start_marker"* ]]; then
+      break
+    fi
+    
+    # Extract content before the start marker
+    local before_match="${remaining_content%%$start_marker*}"
     processed_content+="$before_match"
+    
+    # Remove the processed part and the start marker
+    remaining_content="${remaining_content#*$start_marker}"
+    
+    # Find the end marker
+    if [[ "$remaining_content" != *"$end_marker"* ]]; then
+      log_error "Found $start_marker without matching $end_marker in migration: $migration_name"
+      return 1
+    fi
+    
+    # Extract the prompt content
+    local prompt="${remaining_content%%$end_marker*}"
     
     # Trim whitespace from prompt
     prompt=$(echo "$prompt" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -383,8 +401,8 @@ process_migration() {
     # Add the result (without the prompt markers or the prompt itself)
     processed_content+="$result"
     
-    # Update remaining content to start after the closing marker
-    remaining_content="${remaining_content#*{{/CLAUDE_PROMPT}}}"
+    # Update remaining content to start after the end marker
+    remaining_content="${remaining_content#*$end_marker}"
   done
   
   # Add any remaining content
@@ -443,6 +461,163 @@ create_symlink() {
       log_success "Created symlink: $target -> $source"
     fi
   fi
+}
+
+# Wrap lines in markdown content while preserving formatting
+wrap_markdown_content() {
+  local content="$1"
+  local max_width=120
+  
+  # Check if fmt is available
+  if ! command_exists fmt; then
+    log_warning "fmt command not found. Skipping line wrapping."
+    echo "$content"
+    return 0
+  fi
+  
+  # Create temporary files for processing
+  local temp_input=$(mktemp)
+  local temp_output=$(mktemp)
+  local temp_code=$(mktemp)
+  
+  # Write content to temp file
+  echo "$content" > "$temp_input"
+  
+  # Track if we're in a code block
+  local in_code_block=false
+  local code_block_delimiter=""
+  local line_num=0
+  
+  # Process line by line
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    
+    # Check for code block markers
+    if [[ "$line" =~ ^(\`{3,}|\~{3,}) ]]; then
+      if [[ "$in_code_block" == "false" ]]; then
+        in_code_block=true
+        code_block_delimiter="${BASH_REMATCH[1]}"
+        echo "$line" >> "$temp_output"
+        continue
+      elif [[ "$line" =~ ^${code_block_delimiter} ]]; then
+        in_code_block=false
+        code_block_delimiter=""
+        echo "$line" >> "$temp_output"
+        continue
+      fi
+    fi
+    
+    # If in code block, preserve as-is
+    if [[ "$in_code_block" == "true" ]]; then
+      echo "$line" >> "$temp_output"
+      continue
+    fi
+    
+    # Handle special markdown elements
+    # Headers (preserve as-is)
+    if [[ "$line" =~ ^#+ ]]; then
+      echo "$line" >> "$temp_output"
+      continue
+    fi
+    
+    # Empty lines (preserve)
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*$ ]]; then
+      echo "$line" >> "$temp_output"
+      continue
+    fi
+    
+    # Lists - handle specially to preserve indentation
+    if [[ "$line" =~ ^([[:space:]]*)([*+-]|[0-9]+\.)([[:space:]]+)(.*)$ ]]; then
+      local indent="${BASH_REMATCH[1]}"
+      local marker="${BASH_REMATCH[2]}"
+      local space="${BASH_REMATCH[3]}"
+      local content="${BASH_REMATCH[4]}"
+      
+      # Check if content is empty or just whitespace
+      if [[ -z "$content" || "$content" =~ ^[[:space:]]*$ ]]; then
+        echo "$line" >> "$temp_output"
+        continue
+      fi
+      
+      # Check if content contains a URL
+      if [[ "$content" =~ https?://[^[:space:]]+ ]]; then
+        echo "$line" >> "$temp_output"
+      else
+        # Calculate available width for content
+        local prefix_len=$((${#indent} + ${#marker} + ${#space}))
+        local content_width=$((max_width - prefix_len))
+        
+        # Ensure we have a positive width
+        if [[ $content_width -lt 20 ]]; then
+          # Line is already too indented, just preserve it
+          echo "$line" >> "$temp_output"
+        else
+          # Wrap the content part only
+          local wrapped_content=$(echo "$content" | fmt -w $content_width)
+          local first_line=true
+          while IFS= read -r wrapped_line; do
+            if [[ "$first_line" == "true" ]]; then
+              echo "${indent}${marker}${space}${wrapped_line}" >> "$temp_output"
+              first_line=false
+            else
+              # Continuation lines get extra indentation
+              echo "${indent}    ${wrapped_line}" >> "$temp_output"
+            fi
+          done <<< "$wrapped_content"
+        fi
+      fi
+      continue
+    fi
+    
+    # Block quotes
+    if [[ "$line" =~ ^(\>+[[:space:]]*)(.*)$ ]]; then
+      local quote_marker="${BASH_REMATCH[1]}"
+      local content="${BASH_REMATCH[2]}"
+      
+      # Check if content is empty
+      if [[ -z "$content" || "$content" =~ ^[[:space:]]*$ ]]; then
+        echo "$line" >> "$temp_output"
+        continue
+      fi
+      
+      # Check if content contains a URL
+      if [[ "$content" =~ https?://[^[:space:]]+ ]]; then
+        echo "$line" >> "$temp_output"
+      else
+        # Calculate available width
+        local quote_width=$((max_width - ${#quote_marker}))
+        if [[ $quote_width -lt 20 ]]; then
+          # Too narrow, preserve as-is
+          echo "$line" >> "$temp_output"
+        else
+          # Wrap the content part only
+          local wrapped_content=$(echo "$content" | fmt -w $quote_width)
+          while IFS= read -r wrapped_line; do
+            echo "${quote_marker}${wrapped_line}" >> "$temp_output"
+          done <<< "$wrapped_content"
+        fi
+      fi
+      continue
+    fi
+    
+    # Regular paragraphs - check for URLs
+    if [[ "$line" =~ https?://[^[:space:]]+ ]]; then
+      # Line contains URL, preserve as-is
+      echo "$line" >> "$temp_output"
+    else
+      # Wrap normal text
+      echo "$line" | fmt -w $max_width >> "$temp_output"
+    fi
+    
+  done < "$temp_input"
+  
+  # Read the wrapped content
+  local wrapped_content=$(cat "$temp_output")
+  
+  # Clean up temp files
+  rm -f "$temp_input" "$temp_output" "$temp_code"
+  
+  echo "$wrapped_content"
 }
 
 # Run dedupe command
@@ -575,6 +750,16 @@ main() {
     local migration_number=$(basename "$migration" | grep -o '^[0-9]\+' || echo "0")
     current_version=$migration_number
   done
+  
+  # Wrap lines before writing
+  log_verbose "Wrapping lines to 120 characters..."
+  local wrapped_content
+  if wrapped_content=$(wrap_markdown_content "$agents_content"); then
+    agents_content="$wrapped_content"
+    log_verbose "Line wrapping completed successfully"
+  else
+    log_warning "Line wrapping failed, using unwrapped content"
+  fi
   
   # Write AGENTS.md
   echo -e "$agents_content" > "$agents_file"

--- a/docs/agentsmd-guide.md
+++ b/docs/agentsmd-guide.md
@@ -25,6 +25,7 @@ agentsmd --list-migrations
 3. **Analyzes Projects**: Uses Claude Code to generate project-specific documentation
 4. **Tracks Versions**: Prevents duplicate migrations with `.agentyard-version.yml`
 5. **Caches Results**: Stores Claude analysis results for performance
+6. **Line Wrapping**: Automatically wraps lines to 120 characters while preserving markdown formatting
 
 ## How It Works
 
@@ -48,7 +49,7 @@ Analyze this repository and provide a 2-3 sentence overview.
 {{/CLAUDE_PROMPT}}
 ```
 
-Everything between `{{CLAUDE_PROMPT}}` and `{{/CLAUDE_PROMPT}}` is sent to Claude Code, and the output replaces the entire block.
+Everything between `{{CLAUDE_PROMPT}}` and `{{/CLAUDE_PROMPT}}` is sent to Claude Code, and only the response (not the prompt or markers) is included in the output.
 
 ### Version Tracking
 
@@ -67,6 +68,17 @@ Claude analysis results are cached in `~/agentyard/agentsmd/cache/` to avoid red
 - The repository changes (git commit hash)
 - Key project files are modified
 - You use the `--no-cache` option
+
+### Line Wrapping
+
+After all migrations are processed, the AGENTS.md content is automatically wrapped to keep lines under 120 characters for better readability. The wrapping is intelligent and preserves:
+- **Headers**: Remain on single lines regardless of length
+- **Code blocks**: Content between ``` markers is never wrapped
+- **Lists**: Proper indentation is maintained with continuation lines
+- **URLs**: Never broken across lines even if they exceed 120 characters
+- **Blockquotes**: Each wrapped line maintains the > prefix
+
+If the `fmt` command is not available, line wrapping is skipped with a warning.
 
 ## Command Options
 

--- a/tests/test_agentsmd_wrapping.sh
+++ b/tests/test_agentsmd_wrapping.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+#
+# test_agentsmd_wrapping.sh - Test suite for agentsmd line wrapping functionality
+#
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test setup
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AGENTSMD_CMD="${PROJECT_ROOT}/bin/agentsmd"
+
+# Extract just the functions we need from agentsmd without running the main code
+# This prevents the script from executing when sourced
+AGENTSMD_SOURCED=true
+
+# Define minimal versions of dependencies
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Source only the function definitions
+eval "$(sed -n '/^wrap_markdown_content()/,/^}/p' "${PROJECT_ROOT}/bin/agentsmd")"
+eval "$(sed -n '/^process_migration()/,/^}/p' "${PROJECT_ROOT}/bin/agentsmd")"
+
+# Define minimal versions of logging functions used by process_migration
+log_error() { echo "ERROR: $*" >&2; }
+log_verbose() { :; }  # no-op for tests
+
+# Mock functions for process_migration test
+generate_cache_key() { echo "test-cache-key"; }
+get_cache_path() { echo "/tmp/test-cache"; }
+run_claude_analysis() {
+    # This will be overridden in specific tests
+    echo "Mock Claude response"
+}
+
+# Define log_warning for tests
+log_warning() {
+    echo "[WARNING] $*" >&2
+}
+
+# Test assertion functions
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo -e "  Expected: '$expected'"
+        echo -e "  Actual:   '$actual'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_line_length() {
+    local content="$1"
+    local max_length="$2"
+    local test_name="$3"
+    local allow_urls="${4:-false}"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local all_good=true
+    local line_num=0
+    
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        local len=${#line}
+        
+        # Skip URL lines if allowed
+        if [[ "$allow_urls" == "true" ]] && [[ "$line" =~ https?://[^[:space:]]+ ]]; then
+            continue
+        fi
+        
+        if [[ $len -gt $max_length ]]; then
+            if [[ "$all_good" == "true" ]]; then
+                echo -e "${RED}✗${NC} $test_name"
+                all_good=false
+            fi
+            echo -e "  Line $line_num exceeds $max_length chars (length: $len)"
+            echo -e "  Content: '${line:0:50}...'"
+        fi
+    done <<< "$content"
+    
+    if [[ "$all_good" == "true" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local pattern="$2"
+    local test_name="$3"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$content" | grep -q "$pattern"; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo -e "  Pattern not found: $pattern"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local pattern="$2"
+    local test_name="$3"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! echo "$content" | grep -q "$pattern"; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo -e "  Pattern found but should not be: $pattern"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Test functions
+test_basic_wrapping() {
+    echo -e "\n${YELLOW}Testing basic text wrapping...${NC}"
+    
+    local input="This is a very long line that definitely exceeds 120 characters and should be wrapped to fit within the specified limit without breaking words in the middle of them."
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "Basic text wrapped to 120 chars"
+    assert_contains "$output" "This is a very long line" "Content preserved"
+}
+
+test_header_preservation() {
+    echo -e "\n${YELLOW}Testing header preservation...${NC}"
+    
+    local input="# This is a very long header that exceeds 120 characters and normally would be wrapped but headers should be preserved as-is without any wrapping applied to them"
+    local output=$(wrap_markdown_content "$input")
+    
+    # Headers should not be wrapped
+    local line_count=$(echo "$output" | wc -l | tr -d ' ')
+    assert_equals "1" "$line_count" "Header remains on single line"
+    assert_contains "$output" "# This is a very long header" "Header content preserved"
+}
+
+test_code_block_preservation() {
+    echo -e "\n${YELLOW}Testing code block preservation...${NC}"
+    
+    local input='```bash
+This is a very long line inside a code block that definitely exceeds 120 characters and should NOT be wrapped because code blocks must be preserved exactly as they are written.
+echo "Another line in the code block"
+```'
+    
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_contains "$output" "This is a very long line inside a code block that definitely exceeds 120 characters" "Long code line preserved"
+    assert_contains "$output" '```bash' "Code block start preserved"
+    assert_contains "$output" '```' "Code block end preserved"
+}
+
+test_list_formatting() {
+    echo -e "\n${YELLOW}Testing list formatting...${NC}"
+    
+    local input="- This is a very long list item that exceeds 120 characters and should be wrapped while preserving the list marker and proper indentation for continuation lines
+- Short item
+  - This is a nested list item that is also very long and exceeds 120 characters so it needs to be wrapped while maintaining the nested indentation properly"
+    
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "List items wrapped to 120 chars"
+    assert_contains "$output" "^- This is a very long list item" "List marker preserved"
+    assert_contains "$output" "^  - This is a nested list item" "Nested list marker preserved"
+}
+
+test_numbered_list_formatting() {
+    echo -e "\n${YELLOW}Testing numbered list formatting...${NC}"
+    
+    local input="1. This is a very long numbered list item that exceeds 120 characters and should be wrapped while preserving the number marker and proper indentation
+2. Another item
+   1. Nested numbered item that is also quite long and exceeds the 120 character limit so it needs proper wrapping"
+    
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "Numbered list items wrapped"
+    assert_contains "$output" "^1\. This is a very long numbered" "Numbered marker preserved"
+    assert_contains "$output" "^   1\. Nested numbered item" "Nested numbering preserved"
+}
+
+test_url_preservation() {
+    echo -e "\n${YELLOW}Testing URL preservation...${NC}"
+    
+    local input="Check out this documentation at https://github.com/very/long/url/that/exceeds/120/characters/but/should/not/be/broken/because/urls/must/remain/intact/documentation.html for more information."
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_contains "$output" "https://github.com/very/long/url/that/exceeds/120/characters/but/should/not/be/broken/because/urls/must/remain/intact/documentation.html" "URL preserved intact"
+}
+
+test_blockquote_formatting() {
+    echo -e "\n${YELLOW}Testing blockquote formatting...${NC}"
+    
+    local input="> This is a very long blockquote that exceeds 120 characters and should be wrapped while preserving the blockquote marker on each wrapped line to maintain proper formatting"
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "Blockquote wrapped to 120 chars"
+    # Check that each line starts with >
+    local lines_without_marker=$(echo "$output" | grep -v "^>" | wc -l | tr -d ' ')
+    assert_equals "0" "$lines_without_marker" "All blockquote lines have > marker"
+}
+
+test_empty_lines_preservation() {
+    echo -e "\n${YELLOW}Testing empty line preservation...${NC}"
+    
+    local input="First paragraph.
+
+Second paragraph.
+
+
+Third paragraph with double empty line above."
+    
+    local output=$(wrap_markdown_content "$input")
+    
+    # Count empty lines
+    local empty_lines=$(echo "$output" | grep -c "^$" || true)
+    assert_equals "3" "$empty_lines" "Empty lines preserved"
+}
+
+test_mixed_content() {
+    echo -e "\n${YELLOW}Testing mixed content...${NC}"
+    
+    local input='# Header
+
+This is a paragraph with a very long line that needs wrapping because it exceeds the 120 character limit we have set for line wrapping.
+
+- List item one
+- A very long list item that needs to be wrapped because it exceeds 120 characters and we want to maintain readability
+
+```python
+# This code should not be wrapped even if it is very long
+def very_long_function_name_that_exceeds_120_characters_but_should_not_be_wrapped():
+    pass
+```
+
+> A blockquote with a long line that needs wrapping to stay within the 120 character limit while preserving the quote marker'
+    
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "Mixed content respects line limits" "true"
+    assert_contains "$output" "# Header" "Header preserved"
+    assert_contains "$output" "def very_long_function_name_that_exceeds_120_characters_but_should_not_be_wrapped" "Code block preserved"
+    assert_contains "$output" "^- List item one" "List items preserved"
+    assert_contains "$output" "^> A blockquote" "Blockquote preserved"
+}
+
+test_special_characters() {
+    echo -e "\n${YELLOW}Testing special characters...${NC}"
+    
+    local input="This line contains special characters like \$HOME and \`backticks\` and should wrap properly without breaking the special character sequences or escape codes."
+    local output=$(wrap_markdown_content "$input")
+    
+    assert_line_length "$output" 120 "Special chars line wrapped"
+    assert_contains "$output" '\$HOME' "Dollar sign preserved"
+    assert_contains "$output" '`backticks`' "Backticks preserved"
+}
+
+test_no_fmt_fallback() {
+    echo -e "\n${YELLOW}Testing fallback when fmt is not available...${NC}"
+    
+    # Override command_exists for this test
+    local original_command_exists=$(declare -f command_exists)
+    command_exists() {
+        if [[ "$1" == "fmt" ]]; then
+            return 1
+        else
+            command -v "$1" >/dev/null 2>&1
+        fi
+    }
+    
+    # Capture both stdout and stderr
+    local input="This is a test line"
+    local output=$(wrap_markdown_content "$input" 2>&1)
+    
+    # Check if warning was logged (it goes to stderr via log_warning)
+    if [[ "$output" == *"fmt command not found"* ]] || [[ "$output" == *"This is a test line"* ]]; then
+        echo -e "${GREEN}✓${NC} Handles missing fmt gracefully"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} Should handle missing fmt"
+        echo "  Output: $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+    
+    # Restore original command_exists
+    eval "$original_command_exists"
+}
+
+test_prompt_marker_removal() {
+    echo -e "\n${YELLOW}Testing Claude prompt marker removal...${NC}"
+    
+    # Create a test migration file
+    local test_migration=$(mktemp)
+    cat > "$test_migration" <<'EOF'
+# Test Migration
+
+This is before the prompt.
+
+{{CLAUDE_PROMPT}}
+This is the prompt content that should not appear in output.
+List three fruits.
+{{/CLAUDE_PROMPT}}
+
+This is after the prompt.
+EOF
+    
+    # Override run_claude_analysis for this test
+    local original_run_claude=$(declare -f run_claude_analysis)
+    run_claude_analysis() {
+        echo "Apple, Banana, Orange"
+    }
+    
+    # Process the migration
+    local output=$(process_migration "$test_migration" ".")
+    
+    # Restore original function
+    eval "$original_run_claude"
+    
+    # Clean up
+    rm -f "$test_migration"
+    
+    assert_contains "$output" "This is before the prompt" "Content before prompt preserved"
+    assert_contains "$output" "This is after the prompt" "Content after prompt preserved"
+    assert_contains "$output" "Apple, Banana, Orange" "Claude response included"
+    assert_not_contains "$output" "{{CLAUDE_PROMPT}}" "Start marker removed"
+    assert_not_contains "$output" "{{/CLAUDE_PROMPT}}" "End marker removed"
+    assert_not_contains "$output" "This is the prompt content" "Prompt content removed"
+    assert_not_contains "$output" "List three fruits" "Prompt instruction removed"
+}
+
+# Main test runner
+main() {
+    echo -e "${BLUE}================================${NC}"
+    echo -e "${BLUE}Running agentsmd wrapping tests${NC}"
+    echo -e "${BLUE}================================${NC}"
+    
+    # Run all tests
+    test_basic_wrapping
+    test_header_preservation
+    test_code_block_preservation
+    test_list_formatting
+    test_numbered_list_formatting
+    test_url_preservation
+    test_blockquote_formatting
+    test_empty_lines_preservation
+    test_mixed_content
+    test_special_characters
+    test_no_fmt_fallback
+    test_prompt_marker_removal
+    
+    # Summary
+    echo -e "\n${BLUE}================================${NC}"
+    echo -e "${BLUE}Test Summary${NC}"
+    echo -e "${BLUE}================================${NC}"
+    echo -e "Tests run:    $TESTS_RUN"
+    echo -e "${GREEN}Tests passed: $TESTS_PASSED${NC}"
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        echo -e "${RED}Tests failed: $TESTS_FAILED${NC}"
+    else
+        echo -e "Tests failed: $TESTS_FAILED"
+    fi
+    
+    # Exit with appropriate code
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        echo -e "\n${GREEN}All tests passed!${NC}"
+        exit 0
+    else
+        echo -e "\n${RED}Some tests failed!${NC}"
+        exit 1
+    fi
+}
+
+# Run tests
+main


### PR DESCRIPTION
## Summary
- Fixed Claude prompt markers and content appearing in AGENTS.md output
- Added intelligent line wrapping to keep lines under 120 characters
- Preserves markdown formatting (headers, code blocks, lists, URLs)

## Problem Solved
This PR addresses issue #23 where:
1. Claude prompts and their markers were being included in the compiled AGENTS.md file
2. Long lines from Claude responses were not being wrapped, making files hard to read

## Changes Made

### 1. Fixed Claude Prompt Processing
- Modified `process_migration()` to use string-based parsing instead of regex
- Ensures only Claude's response is included in the output
- Removes all prompt markers (`{{CLAUDE_PROMPT}}`, `{{/CLAUDE_PROMPT}}`) and prompt content

### 2. Added Line Wrapping
- New `wrap_markdown_content()` function wraps lines to 120 characters
- Intelligent handling of markdown elements:
  - Headers remain on single lines
  - Code blocks are preserved as-is
  - Lists maintain proper indentation
  - URLs are never broken
  - Blockquotes keep their markers on each line
- Falls back gracefully if `fmt` command is not available

### 3. Comprehensive Testing
- Added `test_agentsmd_wrapping.sh` with 33 test cases
- Tests cover all markdown elements and edge cases
- All existing tests continue to pass

## Test Results
```
Tests run:    33
Tests passed: 33
Tests failed: 0
```

## Documentation
Updated `docs/agentsmd-guide.md` to document the new line wrapping feature and clarify prompt handling.

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)