### PR TITLE
Fix finishtask to support project names with dashes

### DIFF
--- a/bin/finishtask
+++ b/bin/finishtask
@@ -28,7 +28,7 @@ fi
 session_name=$(tmux display-message -p '#S')
 
 # ---- Validate session name format -------------------------------------------
-if [[ ! "$session_name" =~ ^[^-]+-[0-9]+$ ]]; then
+if [[ ! "$session_name" =~ ^[^-]+(-[^-]+)*-[0-9]+$ ]]; then
   echo "Error: Current session '$session_name' doesn't match expected format (project-slug)" >&2
   echo "This command only works with sessions created by starttask" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Updated the regex pattern in `finishtask` to support project names containing dashes
- Changed from `^[^-]+-[0-9]+$` to `^[^-]+(-[^-]+)*-[0-9]+$`
- This allows multiple dash-separated segments in project names

## Problem
The previous regex pattern only allowed a single dash between the project name and the numeric slug. This caused `finishtask` to fail for projects with dashes in their names (like `carlton-poc`), showing the error:
```
Error: Current session 'carlton-poc-001' doesn't match expected format (project-slug)
```

## Solution
The updated regex pattern `^[^-]+(-[^-]+)*-[0-9]+$` allows:
- One or more non-dash characters at the start
- Zero or more groups of dash followed by non-dash characters
- A final dash followed by the numeric slug

This correctly handles project names like:
- `deckard-001` (simple project name)
- `carlton-poc-001` (project name with dash)
- `my-awesome-project-042` (multiple dashes in project name)

## Test plan
- [x] Tested regex pattern with various project name formats
- [x] Verified it correctly rejects invalid formats
- [x] Confirmed it accepts project names with dashes

🤖 Generated with [Claude Code](https://claude.ai/code)